### PR TITLE
ci: enable nilaway scans

### DIFF
--- a/.github/workflows/nilaway.yml
+++ b/.github/workflows/nilaway.yml
@@ -1,0 +1,25 @@
+name: nilaway
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  nilaway:
+    name: nilaway
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0 https://github.com/actions/checkout/releases/tag/v5.0.0
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0 https://github.com/actions/setup-go/releases/tag/v6.0.0
+        with:
+          go-version: 1.25.x
+      - name: install nilaway
+        run: go install go.uber.org/nilaway/cmd/nilaway@latest
+      - name: run nilaway
+        run: nilaway ./...


### PR DESCRIPTION
## Summary

Uber nilaway is a static analysis scanning tool for detecting nil panics. This will prevent many classes of nil pointers from making it into the code.

## Type of Change

- [x] CI / Static Analysis